### PR TITLE
Initial rebranding

### DIFF
--- a/browser/base/content/aboutDialog.css
+++ b/browser/base/content/aboutDialog.css
@@ -26,13 +26,19 @@
   padding: 15px 10px 0;
 }
 
-#version {
+#version,
+#build {
   font-weight: bold;
   margin-top: 10px;
   margin-left: 0;
   -moz-user-select: text;
   -moz-user-focus: normal;
   cursor: text;
+}
+
+#build {
+  font-style: italic;
+  font-weight: lighter;
 }
 
 #version:-moz-locale-dir(rtl) {

--- a/browser/base/content/aboutDialog.js
+++ b/browser/base/content/aboutDialog.js
@@ -32,14 +32,13 @@ function init(aEvent) {
 
   // Include the build ID and display warning if this is an "a#" (nightly or aurora) build
   let versionField = document.getElementById("version");
+  let buildField = document.getElementById("build");
   let version = Services.appinfo.version;
-  if (/a\d+$/.test(version)) {
-    let buildID = Services.appinfo.appBuildID;
-    let year = buildID.slice(0, 4);
-    let month = buildID.slice(4, 6);
-    let day = buildID.slice(6, 8);
-    versionField.textContent += ` (${year}-${month}-${day})`;
+  let buildID = Services.appinfo.appBuildID;
+  
+  buildField.textContent += `(${buildID})`;
 
+  if (/a\d+$/.test(version)) {
     document.getElementById("experimental").hidden = false;
     document.getElementById("communityDesc").hidden = true;
   }

--- a/browser/base/content/aboutDialog.xul
+++ b/browser/base/content/aboutDialog.xul
@@ -49,6 +49,7 @@
           <label id="releasenotes" class="text-link" hidden="true">&releaseNotes.link;</label>
         </hbox>
 
+        <label id="build"></label>
         <label id="distribution" class="text-blurb"/>
         <label id="distributionId" class="text-blurb"/>
 

--- a/browser/branding/official/configure.sh
+++ b/browser/branding/official/configure.sh
@@ -2,4 +2,4 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-MOZ_APP_DISPLAYNAME=Firefox
+MOZ_APP_DISPLAYNAME=Quokka

--- a/browser/branding/official/locales/en-US/brand.dtd
+++ b/browser/branding/official/locales/en-US/brand.dtd
@@ -2,8 +2,8 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-<!ENTITY  brandShorterName      "Firefox">
-<!ENTITY  brandShortName        "Firefox">
-<!ENTITY  brandFullName         "Mozilla Firefox">
-<!ENTITY  vendorShortName       "Mozilla">
-<!ENTITY  trademarkInfo.part1   "Firefox and the Firefox logos are trademarks of the Mozilla Foundation.">
+<!ENTITY  brandShorterName      "Quokka">
+<!ENTITY  brandShortName        "Quokka">
+<!ENTITY  brandFullName         "Quokka">
+<!ENTITY  vendorShortName       "Anima">
+<!ENTITY  trademarkInfo.part1   "Quokka and the Quokka logos are trademarks of the Anima OS developers.">

--- a/browser/branding/official/locales/en-US/brand.properties
+++ b/browser/branding/official/locales/en-US/brand.properties
@@ -2,12 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-brandShorterName=Firefox
-brandShortName=Firefox
-brandFullName=Mozilla Firefox
-vendorShortName=Mozilla
+brandShorterName=Quokka
+brandShortName=Quokka
+brandFullName=Quokka
+vendorShortName=Anima
 
-homePageSingleStartMain=Firefox Start, a fast home page with built-in search
+homePageSingleStartMain=Quokka Start, a fast home page with built-in search
 homePageImport=Import your home page from %S
 
 homePageMigrationPageTitle=Home Page Selection

--- a/browser/config/version_display.txt
+++ b/browser/config/version_display.txt
@@ -1,1 +1,1 @@
-56.0.1
+1 (Codename: Picasso)

--- a/browser/confvars.sh
+++ b/browser/confvars.sh
@@ -3,8 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-MOZ_APP_BASENAME=Firefox
-MOZ_APP_VENDOR=Mozilla
+MOZ_APP_BASENAME=Quokka
+MOZ_APP_VENDOR=Anima
 MOZ_UPDATER=1
 MOZ_PHOENIX=1
 
@@ -61,8 +61,9 @@ else
 fi
 MOZ_PROFILE_MIGRATOR=1
 
-# Enable checking that add-ons are signed by the trusted root
-MOZ_ADDON_SIGNING=1
+# (Temporarily) Disable checking that add-ons are signed by the trusted root
+MOZ_ADDON_SIGNING=0
+MOZ_REQUIRE_SIGNING=0
 
 # Include the DevTools client, not just the server (which is the default)
 MOZ_DEVTOOLS=all

--- a/toolkit/content/about.js
+++ b/toolkit/content/about.js
@@ -19,14 +19,20 @@ if (vendorURL != "about:blank") {
 }
 
 // insert the version of the XUL application (!= XULRunner platform version)
-var versionNum = Components.classes["@mozilla.org/xre/app-info;1"]
-                           .getService(Components.interfaces.nsIXULAppInfo)
-                           .version;
+var versionNum = Components.utils
+                           .import("resource://gre/modules/AppConstants.jsm")
+                           .AppConstants.MOZ_APP_VERSION_DISPLAY;
 var version = document.getElementById("version");
 version.textContent += " " + versionNum;
+
+var buildNum = Components.utils
+                            .import("resource://gre/modules/Services.jsm")
+                            .Services.appinfo.appBuildID;
+var build = document.getElementById("build")
+build.textContent += buildNum;
 
 // append user agent
 var ua = navigator.userAgent;
 if (ua) {
-  document.getElementById("buildID").textContent += " " + ua;
+  document.getElementById("userAgent").textContent += " " + ua;
 }

--- a/toolkit/content/about.xhtml
+++ b/toolkit/content/about.xhtml
@@ -25,6 +25,7 @@
     <a id="vendorURL">
       <img src="about:logo" alt="&brandShortName;"/>
       <p id="version">&about.version;</p>
+      <p id="build">&about.buildIdentifier;</p>
     </a>
   </div>
 
@@ -33,7 +34,7 @@
     <li>&about.license.beforeTheLink;<a href="about:license">&about.license.linkTitle;</a>&about.license.afterTheLink;</li>
     <li hidden="true">&about.relnotes.beforeTheLink;<a id="releaseNotesURL">&about.relnotes.linkTitle;</a>&about.relnotes.afterTheLink;</li>
     <li>&about.buildconfig.beforeTheLink;<a href="about:buildconfig">&about.buildconfig.linkTitle;</a>&about.buildconfig.afterTheLink;</li>
-    <li id="buildID">&about.buildIdentifier;</li>
+    <li id="userAgent">&about.userAgent;</li>
     <script type="application/javascript" src="chrome://global/content/about.js"/>
   </ul>
 

--- a/toolkit/locales/en-US/chrome/global/about.dtd
+++ b/toolkit/locales/en-US/chrome/global/about.dtd
@@ -1,7 +1,7 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<!ENTITY about.version                "version">
+<!ENTITY about.version                "Version">
 
 <!-- LOCALIZATION NOTE (about.credits.beforeLink): note that there is no space between this phrase and the linked about.credits.linkTitle phrase, so if your locale needs a space between words, add it at the end of this entity. -->
 <!ENTITY about.credits.beforeLink     "See a list of ">
@@ -27,4 +27,5 @@
 <!-- LOCALIZATION NOTE (about.buildconfig.afterTheLink): note that there is no space between the linked about.buildconfig.linkTitle phrase and this phrase, so if your locale needs a space between words, add it at the start of this entity. -->
 <!ENTITY about.buildconfig.afterTheLink  " used for this version.">
 
-<!ENTITY about.buildIdentifier        "Build identifier: ">
+<!ENTITY about.buildIdentifier        "Build ID: ">
+<!ENTITY about.userAgent              "User Agent:">

--- a/toolkit/themes/shared/about.css
+++ b/toolkit/themes/shared/about.css
@@ -36,11 +36,16 @@ img {
   border: 0;
 }
 
-#version {
+#version, 
+#build {
   font-weight: bold;
   color: #909090;
   margin: -24px 0 9px 17px;
   text-align: left; /* Override direction alignment on RTL to make sure that the version will fit well on the background. bug 1325232 */
+}
+
+#build {
+  margin: -4px 0 9px 17px;
 }
 
 ul {


### PR DESCRIPTION
Implements initial branding efforts as outlined in issue #2.

Changes base app name to ``Quokka``, implements new display version scheme and disables extension signing requirements.

![2](https://user-images.githubusercontent.com/1962554/33804717-2daca8ba-ddab-11e7-9d07-88277ceb2b32.PNG)
